### PR TITLE
[Feat] #10 - 스크립트 요약 화면 구현

### DIFF
--- a/BeyondTheLine-iOS/BeyondTheLine-iOS.xcodeproj/project.pbxproj
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS.xcodeproj/project.pbxproj
@@ -70,6 +70,14 @@
 		998FD39D2E042A9E00773EB5 /* CustomerCellContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD39C2E042A8E00773EB5 /* CustomerCellContentView.swift */; };
 		998FD39F2E042B1C00773EB5 /* LearningInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD39E2E042B0000773EB5 /* LearningInfoView.swift */; };
 		998FD3A12E05295400773EB5 /* SituationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD3A02E05293B00773EB5 /* SituationModel.swift */; };
+		998FD3AB2E07F9F600773EB5 /* BeyondTheLineScriptBubbleState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD3AA2E07F9CD00773EB5 /* BeyondTheLineScriptBubbleState.swift */; };
+		998FD3AD2E07FB9300773EB5 /* SummaryFeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD3AC2E07FB8600773EB5 /* SummaryFeedbackView.swift */; };
+		998FD3AF2E07FBBA00773EB5 /* SummaryScriptContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD3AE2E07FBAB00773EB5 /* SummaryScriptContentView.swift */; };
+		998FD3B12E07FBD900773EB5 /* SummaryPreTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD3B02E07FBCD00773EB5 /* SummaryPreTextView.swift */; };
+		998FD3B32E08393C00773EB5 /* SummaryBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD3B22E08391800773EB5 /* SummaryBackgroundView.swift */; };
+		998FD3B52E083ABC00773EB5 /* SummaryScriptAnswerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD3B42E083A6F00773EB5 /* SummaryScriptAnswerView.swift */; };
+		998FD3B72E08FFC800773EB5 /* Array+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD3B62E08FFC000773EB5 /* Array+.swift */; };
+		998FD3B92E09048400773EB5 /* SummaryScriptAnswerSubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998FD3B82E09043E00773EB5 /* SummaryScriptAnswerSubView.swift */; };
 		CA6160A22E0146A200C16CF5 /* LastQuizQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6160A12E0146A200C16CF5 /* LastQuizQuestionView.swift */; };
 		CA6160A42E014AA000C16CF5 /* LastQuizSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6160A32E014AA000C16CF5 /* LastQuizSelectionView.swift */; };
 		CA6160A62E01508E00C16CF5 /* LastQuizProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6160A52E01508E00C16CF5 /* LastQuizProgressView.swift */; };
@@ -143,6 +151,14 @@
 		998FD39C2E042A8E00773EB5 /* CustomerCellContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCellContentView.swift; sourceTree = "<group>"; };
 		998FD39E2E042B0000773EB5 /* LearningInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningInfoView.swift; sourceTree = "<group>"; };
 		998FD3A02E05293B00773EB5 /* SituationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SituationModel.swift; sourceTree = "<group>"; };
+		998FD3AA2E07F9CD00773EB5 /* BeyondTheLineScriptBubbleState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeyondTheLineScriptBubbleState.swift; sourceTree = "<group>"; };
+		998FD3AC2E07FB8600773EB5 /* SummaryFeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryFeedbackView.swift; sourceTree = "<group>"; };
+		998FD3AE2E07FBAB00773EB5 /* SummaryScriptContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryScriptContentView.swift; sourceTree = "<group>"; };
+		998FD3B02E07FBCD00773EB5 /* SummaryPreTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryPreTextView.swift; sourceTree = "<group>"; };
+		998FD3B22E08391800773EB5 /* SummaryBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryBackgroundView.swift; sourceTree = "<group>"; };
+		998FD3B42E083A6F00773EB5 /* SummaryScriptAnswerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryScriptAnswerView.swift; sourceTree = "<group>"; };
+		998FD3B62E08FFC000773EB5 /* Array+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+.swift"; sourceTree = "<group>"; };
+		998FD3B82E09043E00773EB5 /* SummaryScriptAnswerSubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryScriptAnswerSubView.swift; sourceTree = "<group>"; };
 		CA6160A12E0146A200C16CF5 /* LastQuizQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastQuizQuestionView.swift; sourceTree = "<group>"; };
 		CA6160A32E014AA000C16CF5 /* LastQuizSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastQuizSelectionView.swift; sourceTree = "<group>"; };
 		CA6160A52E01508E00C16CF5 /* LastQuizProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastQuizProgressView.swift; sourceTree = "<group>"; };
@@ -257,6 +273,7 @@
 		3D28D76A2DF3391200136E48 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				998FD3B62E08FFC000773EB5 /* Array+.swift */,
 				3D9C89E32DFD1B8800FCDD61 /* Text+.swift */,
 			);
 			path = Extensions;
@@ -304,6 +321,7 @@
 				3D9C89312DFC6F3700FCDD61 /* BeyondTheLineSelectedButtonState.swift */,
 				3D9C89D22DFD19A800FCDD61 /* BeyondTheLineBottomSheetType.swift */,
 				3DC8D0392DFDB8A100C031A0 /* BeyondTheLineNavigationBarType.swift */,
+				998FD3AA2E07F9CD00773EB5 /* BeyondTheLineScriptBubbleState.swift */,
 				3D7CDEBD2E00616200B1E801 /* BeyondTheLineSimualtorAlertButtonState.swift */,
 			);
 			path = Foundations;
@@ -525,6 +543,12 @@
 		3D9C8A242DFD21E800FCDD61 /* SubViews */ = {
 			isa = PBXGroup;
 			children = (
+				998FD3B22E08391800773EB5 /* SummaryBackgroundView.swift */,
+				998FD3B02E07FBCD00773EB5 /* SummaryPreTextView.swift */,
+				998FD3AE2E07FBAB00773EB5 /* SummaryScriptContentView.swift */,
+				998FD3B42E083A6F00773EB5 /* SummaryScriptAnswerView.swift */,
+				998FD3B82E09043E00773EB5 /* SummaryScriptAnswerSubView.swift */,
+				998FD3AC2E07FB8600773EB5 /* SummaryFeedbackView.swift */,
 				3D9C8A482DFD236300FCDD61 /* SummaryScriptSubView.swift */,
 			);
 			path = SubViews;
@@ -660,9 +684,11 @@
 				3D9C8A162DFD214300FCDD61 /* BackgroundModel.swift in Sources */,
 				3D9C8A5D2DFD9B5000FCDD61 /* LastQuizModel.swift in Sources */,
 				998FD3992E04250500773EB5 /* CustomerCellView.swift in Sources */,
+				998FD3B72E08FFC800773EB5 /* Array+.swift in Sources */,
 				3D2461222DFBA0A700D9E649 /* BeyondTheLineSelectedButton.swift in Sources */,
 				3D9C89D12DFD194900FCDD61 /* SymbolLiterals.swift in Sources */,
 				998FD3932E041AC800773EB5 /* BackgroundCellView.swift in Sources */,
+				998FD3B12E07FBD900773EB5 /* SummaryPreTextView.swift in Sources */,
 				3D9C8A762DFDACC200FCDD61 /* AppCoordinator.swift in Sources */,
 				3D28D7582DF3366400136E48 /* BeyondTheLine_iOS.xcdatamodeld in Sources */,
 				CA6160A62E01508E00C16CF5 /* LastQuizProgressView.swift in Sources */,
@@ -675,15 +701,19 @@
 				CA6160A82E015EAC00C16CF5 /* LastQuizSelectionContainer.swift in Sources */,
 				3D9C8A0A2DFD207D00FCDD61 /* BridgeView.swift in Sources */,
 				3D28D7592DF3366400136E48 /* BeyondTheLine_iOSApp.swift in Sources */,
+				998FD3B32E08393C00773EB5 /* SummaryBackgroundView.swift in Sources */,
+				998FD3AB2E07F9F600773EB5 /* BeyondTheLineScriptBubbleState.swift in Sources */,
 				3D2461242DFBA0B900D9E649 /* BeyondTheLineProgressIndicator.swift in Sources */,
 				3D7CDEBC2E00613000B1E801 /* BeyondTheLineSimualtorAlertButton.swift in Sources */,
 				3D9C892E2DFC60CA00FCDD61 /* Font+.swift in Sources */,
+				998FD3B52E083ABC00773EB5 /* SummaryScriptAnswerView.swift in Sources */,
 				3D9C89E42DFD1B8800FCDD61 /* Text+.swift in Sources */,
 				998FD39B2E0425FC00773EB5 /* CustomerInfoView.swift in Sources */,
 				3D7CDEBE2E00616200B1E801 /* BeyondTheLineSimualtorAlertButtonState.swift in Sources */,
 				3D9C8A712DFDA8B300FCDD61 /* AppRoute.swift in Sources */,
 				3D9C8A292DFD22A400FCDD61 /* SelectBackgroundSubView.swift in Sources */,
 				3D9C8A572DFD9AD700FCDD61 /* BridgeModel.swift in Sources */,
+				998FD3B92E09048400773EB5 /* SummaryScriptAnswerSubView.swift in Sources */,
 				3D9C8A272DFD229300FCDD61 /* SelectBackgroundViewModel.swift in Sources */,
 				CA6160A42E014AA000C16CF5 /* LastQuizSelectionView.swift in Sources */,
 				3D9C89302DFC666000FCDD61 /* BeyondTheLineButtonState.swift in Sources */,
@@ -692,6 +722,7 @@
 				3D24611E2DFB9FAA00D9E649 /* BeyondTheLineButton.swift in Sources */,
 				CA6160A22E0146A200C16CF5 /* LastQuizQuestionView.swift in Sources */,
 				3D9C89ED2DFD1F3A00FCDD61 /* BeyondTheLineScriptBubble.swift in Sources */,
+				998FD3AD2E07FB9300773EB5 /* SummaryFeedbackView.swift in Sources */,
 				3D28D75B2DF3366400136E48 /* Persistence.swift in Sources */,
 				3D9C89EB2DFD1F2600FCDD61 /* BeyondTheLineQuizAlert.swift in Sources */,
 				3D9C8A082DFD207300FCDD61 /* SimulatorView.swift in Sources */,
@@ -710,6 +741,7 @@
 				3D9C8A512DFD23FF00FCDD61 /* SimulatorSubView.swift in Sources */,
 				3D2461202DFBA08700D9E649 /* BeyondTheLineBottomSheet.swift in Sources */,
 				3D9C8A112DFD20F100FCDD61 /* SummaryScriptView.swift in Sources */,
+				998FD3AF2E07FBBA00773EB5 /* SummaryScriptContentView.swift in Sources */,
 				3D9C8A532DFD9AAC00FCDD61 /* SelectCustomerViewModel.swift in Sources */,
 				3D9C8A412DFD233C00FCDD61 /* LastQuizViewModel.swift in Sources */,
 				998FD3972E04243500773EB5 /* SituationBannerView.swift in Sources */,

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Components/BeyondTheLineScriptBubble.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Components/BeyondTheLineScriptBubble.swift
@@ -8,11 +8,32 @@
 import SwiftUI
 
 struct BeyondTheLineScriptBubble: View {
+    let text: String
+    let type: BeyondTheLineScriptBubbleState
+    var isMeasuring: Bool = false
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        HStack {
+            Text(text.forceCharWrapping)
+                .padding(type.InsetPadding)
+                .font(.body1)
+                .foregroundStyle(type.foregroundColor)
+                .background(type.backgroundColor)
+                .clipShape(UnevenRoundedRectangle(cornerRadii: type.cornerRadii))
+                .multilineTextAlignment(.leading)
+                .padding(type.framePadding)
+        }
+    }
+}
+extension String {
+    /// forceCharWrapping - 줄바꿈을 단어가 아닌 글자 기준으로 변경하기 위해 사용
+    var forceCharWrapping: Self {
+        self.map({ String($0) }).joined(separator: "\u{200B}") // 200B: 가로폭 없는 공백문자
     }
 }
 
 #Preview {
-    BeyondTheLineScriptBubble()
+    BeyondTheLineScriptBubble(text: "테스트", type: .answer)
+    BeyondTheLineScriptBubble(text: "테스트", type: .customer)
+    BeyondTheLineScriptBubble(text: "테스트", type: .feedback)
 }

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Extensions/Array+.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Extensions/Array+.swift
@@ -1,0 +1,13 @@
+//
+//  Array+.swift
+//  BeyondTheLine-iOS
+//
+//  Created by 배현진 on 6/23/25.
+//
+
+extension Array {
+    /// 인덱스 범위를 벗어나도 앱이 크래시 나지 않도록 nil  처리
+    subscript(safe index: Int) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Foundations/BeyondTheLineScriptBubbleState.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Foundations/BeyondTheLineScriptBubbleState.swift
@@ -1,0 +1,65 @@
+//
+//  BeyondTheLineScriptBubbleState.swift
+//  BeyondTheLine-iOS
+//
+//  Created by 배현진 on 6/22/25.
+//
+
+import SwiftUI
+
+enum BeyondTheLineScriptBubbleState {
+    case customer
+    case answer
+    case feedback
+    
+    var foregroundColor: Color {
+        switch self {
+        case .customer, .answer: return .btlGray10Normal
+        case .feedback: return .btlGreen35
+        }
+    }
+    
+    var backgroundColor: Color {
+        switch self {
+        case .customer: return .btlBlue80
+        case .answer: return .btlWhite
+        case .feedback: return .btlGreen90Light
+        }
+    }
+    
+    var alignment: Alignment {
+        switch self {
+        case .customer: return .leading
+        case .answer, .feedback: return .trailing
+        }
+    }
+    
+    var cornerRadii: RectangleCornerRadii {
+        switch self {
+        case .customer:
+            return .init(topLeading: 0, bottomLeading: 14, bottomTrailing: 14, topTrailing: 14)
+        case .answer:
+            return .init(topLeading: 14, bottomLeading: 14, bottomTrailing: 14, topTrailing: 0)
+        case .feedback:
+            return .init(topLeading: 0, bottomLeading: 14, bottomTrailing: 14, topTrailing: 0)
+        }
+    }
+    
+    var framePadding: EdgeInsets {
+        switch self {
+        case .customer:
+            return .init(top: 0, leading: 0, bottom: 16, trailing: 0)
+        case .answer, .feedback:
+            return .init(top: 0, leading: 0, bottom: 0, trailing: 0)
+        }
+    }
+    
+    var InsetPadding: EdgeInsets {
+        switch self {
+        case .customer, .answer:
+            return .init(top: 12, leading: 12, bottom: 12, trailing: 12)
+        case .feedback:
+            return .init(top: 24, leading: 12, bottom: 12, trailing: 12)
+        }
+    }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Resources/Colors.xcassets/BTLBlue80.colorset/Contents.json
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Resources/Colors.xcassets/BTLBlue80.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xEC",
+          "red" : "0xE7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Resources/Colors.xcassets/BTLGreen35.colorset/Contents.json
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Core/Resources/Colors.xcassets/BTLGreen35.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x75",
+          "green" : "0xAD",
+          "red" : "0x05"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Data/BeyondTheLine_iOS.xcdatamodeld/BeyondTheLine_iOS.xcdatamodel/contents
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Data/BeyondTheLine_iOS.xcdatamodeld/BeyondTheLine_iOS.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24233.11" systemVersion="25A5279m" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24E248" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Background" representedClassName="Background" syncable="YES" codeGenerationType="class">
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <relationship name="situations" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Situation" inverseName="background" inverseEntity="Situation"/>
@@ -13,7 +13,7 @@
         <attribute name="rules" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="summaryFeedbacks" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <relationship name="lastQuizs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Quiz" inverseName="customer" inverseEntity="Quiz"/>
-        <relationship name="simulatorQuizs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SimulatorQuiz" inverseName="customer" inverseEntity="SimulatorQuiz"/>
+        <relationship name="simulatorQuizs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="SimulatorQuiz" inverseName="customer" inverseEntity="SimulatorQuiz"/>
         <relationship name="situation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Situation" inverseName="customers" inverseEntity="Situation"/>
     </entity>
     <entity name="Quiz" representedClassName="Quiz" syncable="YES" codeGenerationType="class">
@@ -29,6 +29,7 @@
         <attribute name="correctAnswer" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isWarning" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="preText" optional="YES" attributeType="String"/>
         <attribute name="wrongAnswer" optional="YES" attributeType="String"/>
         <relationship name="customer" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Customer" inverseName="simulatorQuizs" inverseEntity="Customer"/>

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Data/Persistence.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Data/Persistence.swift
@@ -68,6 +68,7 @@ extension PersistenceController {
         
         let simQuiz1 = SimulatorQuiz(context: context)
         simQuiz1.id = UUID()
+        simQuiz1.order = 1
         simQuiz1.preText = "아이스 바닐라라떼에 샷 2번만 넣어주시고요.\n시럽은 빼고, 우유는 두유로 바꿔주시고,\n얼음은 적게 부탁드릴게요."
         simQuiz1.correctAnswer = "네 맞아요~ 완전 감사해요!"
         simQuiz1.wrongAnswer = "......?"
@@ -85,13 +86,14 @@ extension PersistenceController {
         quiz1.feedbacks = [
             "이런 반응은 고객에게 부담을 줄 수 있어요.\n복잡한 주문일수록 정리해서 복창하는 것이 좋아요.",
             "일부만 확인하면 나머지 요청을 놓치기 쉬워요.\n전체 요청을 정리해서 확인하는 편이 좋아요.",
-            "고객의 요청을 정확히 정리해 복창하는 방식은\n실수를 줄이고, 신뢰를 줍니다."
+            "고객의 요청을 정확히 정리해 복창하는 방   식은 실수를 줄이고, 신뢰를 줍니다."
         ] as NSArray
         
         // MARK: - Simulator Quiz (2)
 
         let simQuiz2 = SimulatorQuiz(context: context)
         simQuiz2.id = UUID()
+        simQuiz2.order = 2
         simQuiz2.preText = "옆에서 듣던 동료가\n지금 두유가 품절이라고 얘기했어요."
         simQuiz2.correctAnswer = "그럼 저지방으로 바꿔주세요."
         simQuiz2.wrongAnswer = "......?"
@@ -108,7 +110,7 @@ extension PersistenceController {
         quiz2.answerIndex = 1
         quiz2.feedbacks = [
             "고객의 선택을 제한하는 말투는 지양해야 해요.",
-            "대안과 선택지를 함께 제시하는 방식은\n고객의 불편을 줄여줍니다.",
+            "대안과 선택지를 함께 제시하는 방식은, 고객의 불편을 줄여줍니다.",
             "고객의 선택권을 무시하는 응답입니다."
         ] as NSArray
         
@@ -116,6 +118,7 @@ extension PersistenceController {
 
         let simQuiz3 = SimulatorQuiz(context: context)
         simQuiz3.id = UUID()
+        simQuiz3.order = 3
         simQuiz3.preText = ""
         simQuiz3.correctAnswer = "감사합니다."
         simQuiz3.wrongAnswer = "......?"
@@ -131,7 +134,7 @@ extension PersistenceController {
         ] as NSArray
         quiz3.answerIndex = 0
         quiz3.feedbacks = [
-            "주문 내용을 잘 이해했음을 표현하고,\n고객의 요청을 존중하는 따뜻한 응답이에요.",
+            "주문 내용을 이해했음을 표현하고, 고객의 요청을 존중하는 따뜻한 응답이에요.",
             "농담처럼 들릴 수 있지만, 고객이 부담을 느낄 수 있어요.",
             "빠른 응대처럼 보일 수 있으나, 친절도가 낮아 보여요."
         ] as NSArray
@@ -165,6 +168,11 @@ extension PersistenceController {
         // MARK: - Add Array
         
         customer1.simulatorQuizs = [simQuiz1, simQuiz2, simQuiz3]
+        
+        simQuiz1.quizs = [quiz1]
+        simQuiz2.quizs = [quiz2]
+        simQuiz3.quizs = [quiz3]
+        
         customer1.lastQuizs = [lastQuiz1, lastQuiz2]
         
         situation1.customers = [customer1]

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/Model/SummaryScriptModel.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/Model/SummaryScriptModel.swift
@@ -6,3 +6,14 @@
 //
 
 import Foundation
+
+struct SummaryScriptModel: Identifiable {
+    let id: Int
+    let order: Int
+    let customerText: String
+    let isWarning: Bool
+    let answerText: String
+    let correctAnswerText: String
+    let feedbackText: String
+    var isFeedbackVisible: Bool = false
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryBackgroundView.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryBackgroundView.swift
@@ -1,0 +1,24 @@
+//
+//  SummaryBackgroundView.swift
+//  BeyondTheLine-iOS
+//
+//  Created by 배현진 on 6/22/25.
+//
+
+import SwiftUI
+
+struct SummaryBackgroundView: View {
+    var body: some View {
+        Rectangle()
+            .fill(
+                LinearGradient(
+                    gradient: Gradient(colors: [.btlWhite.opacity(0.0), .btlWhite.opacity(0.95)]),
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .frame(width: UIScreen.main.bounds.width, height: 108)
+            .cornerRadius(20)
+            .allowsHitTesting(false)
+    }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryFeedbackView.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryFeedbackView.swift
@@ -1,0 +1,39 @@
+//
+//  SummaryFeedbackView.swift
+//  BeyondTheLine-iOS
+//
+//  Created by 배현진 on 6/22/25.
+//
+
+import SwiftUI
+
+struct SummaryFeedbackView: View {
+    let feedbacks: [String]
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("전체 피드백")
+                .font(.title2)
+                .foregroundColor(.btlBlue40Heavy)
+                .multilineTextAlignment(.center)
+            
+            ForEach(Array(feedbacks.enumerated()), id: \.element) { index, feedback in
+                HStack(alignment: .top) {
+                    Image(systemName: "\(index + 1).circle.fill")
+                        .foregroundColor(.btlBlue40Heavy)
+                    Text(feedback)
+                        .font(.caption1)
+                        .foregroundColor(.btlGray15SemiNormal)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+        }
+        .padding(.vertical, 18)
+        .padding(.horizontal, 16)
+        .background(.btlBlue80)
+        .cornerRadius(16)
+        .padding(.top, 52)
+        .padding(.bottom, 140)
+        .padding(.horizontal, 18)
+    }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryPreTextView.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryPreTextView.swift
@@ -1,0 +1,21 @@
+//
+//  SummaryPreTextView.swift
+//  BeyondTheLine-iOS
+//
+//  Created by 배현진 on 6/22/25.
+//
+
+import SwiftUI
+
+struct SummaryPreTextView: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.body1)
+            .foregroundStyle(.btlGray45LabelAssistive1)
+            .multilineTextAlignment(.center)
+            .padding(.top, 14)
+            .padding(.bottom, 30)
+    }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryScriptAnswerSubView.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryScriptAnswerSubView.swift
@@ -1,0 +1,56 @@
+//
+//  SummaryScriptAnswerSubView.swift
+//  BeyondTheLine-iOS
+//
+//  Created by 배현진 on 6/23/25.
+//
+
+import SwiftUI
+
+struct SummaryScriptAnswerSubView: View {
+    let quiz: SummaryScriptModel
+    @Binding var bubbleMaxWidth: CGFloat
+    @Binding var answerHeight: CGFloat
+    @Binding var feedbackHeight: CGFloat
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 0) {
+            BeyondTheLineScriptBubble(text: quiz.answerText, type: .answer)
+                .background(
+                    GeometryReader { geo in
+                        Color.clear
+                            .onAppear {
+                                DispatchQueue.main.async {
+                                    bubbleMaxWidth = geo.size.width
+                                    answerHeight = geo.size.height
+                                }
+                            }
+                        
+                    }
+                )
+                .frame(maxWidth: bubbleMaxWidth)
+                .zIndex(1)
+            
+            if quiz.isFeedbackVisible {
+                BeyondTheLineScriptBubble(text: quiz.feedbackText, type: .feedback)
+                    .background(
+                        GeometryReader { geo in
+                            Color.clear
+                                .onAppear {
+                                    DispatchQueue.main.async {
+                                        feedbackHeight += geo.size.height
+                                    }
+                                }
+                                .onDisappear {
+                                    DispatchQueue.main.async {
+                                        feedbackHeight = 0
+                                    }
+                                }
+                        }
+                    )
+                    .frame(width: bubbleMaxWidth)
+                    .offset(y: -12)
+            }
+        }
+    }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryScriptAnswerView.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryScriptAnswerView.swift
@@ -1,0 +1,55 @@
+//
+//  SummaryScriptAnswerView.swift
+//  BeyondTheLine-iOS
+//
+//  Created by 배현진 on 6/22/25.
+//
+
+import SwiftUI
+
+struct SummaryScriptAnswerView: View {
+    let quiz: SummaryScriptModel
+    let toggleFeedback: () -> Void
+    
+    @State private var bubbleMaxWidth: CGFloat = .infinity
+    @State private var answerHeight: CGFloat = 0
+    @State private var feedbackHeight: CGFloat = 0
+
+    private var totalHeight: CGFloat {
+        answerHeight + (quiz.isFeedbackVisible ? feedbackHeight : 0)
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 0) {
+            Spacer()
+            
+            Button {
+                withAnimation {
+                    toggleFeedback()
+                }
+            } label: {
+                Image(systemName: "plus.magnifyingglass")
+                    .foregroundStyle(.btlGreen50Normal)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 9)
+                    .background(
+                        Circle()
+                            .fill(.btlWhite)
+                    )
+            }
+            .padding(.trailing, 10)
+            
+            SummaryScriptAnswerSubView(
+                quiz: quiz,
+                bubbleMaxWidth: $bubbleMaxWidth,
+                answerHeight: $answerHeight,
+                feedbackHeight: $feedbackHeight
+            )
+            .padding(.bottom, 12)
+            .animation(.easeInOut(duration: 0.3), value: totalHeight)
+            .alignmentGuide(VerticalAlignment.center) { dimension in
+                dimension[.top] + (totalHeight / 2)
+            }
+        }
+    }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryScriptContentView.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryScriptContentView.swift
@@ -1,0 +1,34 @@
+//
+//  SummaryScriptContentView.swift
+//  BeyondTheLine-iOS
+//
+//  Created by 배현진 on 6/22/25.
+//
+
+import SwiftUI
+
+struct SummaryScriptContentView: View {
+    let quiz: SummaryScriptModel
+    let toggleFeedback: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .center) {
+            // 상황 전개 + 손님 요청
+            if quiz.isWarning {
+                SummaryPreTextView(text: quiz.customerText)
+            } else if !quiz.customerText.isEmpty {
+                BeyondTheLineScriptBubble(text: quiz.customerText, type: .customer)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            
+            // 답변 + 버튼 + 피드백
+            SummaryScriptAnswerView(quiz: quiz, toggleFeedback: toggleFeedback)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            
+            // 정답 텍스트
+            BeyondTheLineScriptBubble(text: quiz.correctAnswerText, type: .customer)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 18)
+    }
+}

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryScriptSubView.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SubViews/SummaryScriptSubView.swift
@@ -8,11 +8,29 @@
 import SwiftUI
 
 struct SummaryScriptSubView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
-}
+    @Binding var quizzes: [SummaryScriptModel]
+    let customerIntro: String
+    let feedbacks: [String]
+    let onToggleFeedback: (SummaryScriptModel) -> Void
 
-#Preview {
-    SummaryScriptSubView()
+    var body: some View {
+        VStack {
+            BeyondTheLineNavigationBar(leadingType: .none, centerType: .title(title: "요약"))
+                .padding(.bottom, 16)
+            
+            ScrollView {
+                SummaryPreTextView(text: customerIntro)
+                
+                ForEach(quizzes) { quiz in
+                    SummaryScriptContentView(quiz: quiz, toggleFeedback: {
+                        onToggleFeedback(quiz)
+                    })
+                }
+                
+                SummaryFeedbackView(feedbacks: feedbacks)
+            }
+        }
+        .background(.btlGray90)
+        .toolbar(.hidden, for: .navigationBar)
+    }
 }

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SummaryScriptView.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/SummaryScriptView.swift
@@ -8,11 +8,38 @@
 import SwiftUI
 
 struct SummaryScriptView: View {
+    @Environment(\.managedObjectContext) private var viewContext
     @EnvironmentObject var coordinator: AppCoordinator
     @ObservedObject var viewModel: SummaryScriptViewModel
+    
+    private var bottomPadding: CGFloat {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows
+            .first { $0.isKeyWindow }?
+            .safeAreaInsets.bottom ?? 0
+    }
 
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack(alignment: .bottom) {
+            SummaryScriptSubView(
+                quizzes: $viewModel.quizzes,
+                customerIntro: viewModel.customerIntro,
+                feedbacks: viewModel.feedbacks,
+                onToggleFeedback: viewModel.toggleFeedback(for:)
+            )
+            
+            SummaryBackgroundView()
+            
+            BeyondTheLineButton(title: "학습 완료", buttonState: .abled, action: {
+                viewModel.selectFinish(coordinator: coordinator, context: viewContext)
+            })
+                .padding(.bottom, bottomPadding)
+        }
+        .ignoresSafeArea(edges: .bottom)
+        .onAppear {
+            viewModel.fetchSimulationData(context: viewContext)
+        }
     }
 }
 

--- a/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/ViewModel/SummaryScriptViewModel.swift
+++ b/BeyondTheLine-iOS/BeyondTheLine-iOS/Presentation/SummaryScript/ViewModel/SummaryScriptViewModel.swift
@@ -5,8 +5,77 @@
 //  Created by mini on 6/14/25.
 //
 
+import CoreData
 import Foundation
 
 final class SummaryScriptViewModel: ObservableObject {
+    @Published var customerIntro: String = ""
+    @Published var quizzes: [SummaryScriptModel] = []
+    @Published var feedbacks: [String] = []
+
+    // TODO: - 손님 상항 전달받아 사용하도록 수정
+    private var customer: Customer?
+
+    func fetchSimulationData(context: NSManagedObjectContext) {
+        let request: NSFetchRequest<Customer> = Customer.fetchRequest()
+        request.fetchLimit = 1
+        
+        do {
+            if let customer = try context.fetch(request).first {
+                self.customer = customer
+                customerIntro = customer.introMessage ?? ""
+                feedbacks = (customer.summaryFeedbacks as? [String]) ?? []
+                
+                let simQuizzes = (customer.simulatorQuizs?.sortedArray(
+                    using: [NSSortDescriptor(
+                        key: #keyPath(SimulatorQuiz.order),
+                        ascending: true)
+                    ]) as? [SimulatorQuiz]) ?? []
+                quizzes = simQuizzes.enumerated().compactMap { idx, quiz in
+                    guard let pre = quiz.preText,
+                          let quizSet = quiz.quizs as? Set<Quiz>,
+                          let quizEntity = quizSet.first,
+                          let answers = quizEntity.answers as? [String],
+                          let feedbacks = quizEntity.feedbacks as? [String]
+                    else { return nil }
+                    
+                    let quizWarning = quiz.isWarning
+                    let quizAnswer = quiz.correctAnswer
+                    let correctIdx = Int(quizEntity.answerIndex)
+                    
+                    return SummaryScriptModel(
+                        id: idx,
+                        order: Int(quiz.order),
+                        customerText: pre,
+                        isWarning: quizWarning,
+                        answerText: answers[safe: correctIdx] ?? "",
+                        correctAnswerText: quizAnswer ?? "",
+                        feedbackText: feedbacks[safe: correctIdx] ?? ""
+                    )
+                }
+            }
+        } catch {
+            print("CoreData fetch error: \(error.localizedDescription)")
+            // TODO: - 에러 처리 방식 개선
+        }
+    }
     
+    func toggleFeedback(for quiz: SummaryScriptModel) {
+        guard let index = quizzes.firstIndex(where: { $0.id == quiz.id }) else { return }
+        quizzes[index].isFeedbackVisible.toggle()
+    }
+    
+    @MainActor
+    func selectFinish(coordinator: AppCoordinator, context: NSManagedObjectContext) {
+        if let customer = customer {
+            customer.learningCount += 1
+            do {
+                try context.save()
+                print("Success learningCount Add: \(customer.learningCount)")
+            } catch {
+                print("Fail learningCount Add: \(error)")
+            }
+        }
+        coordinator.popToRoot()
+    }
 }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #10

## 🔍 PR Content
<!-- 작업 내용 설명 -->
스크립트 요약 화면을 구현하였습니다. 
피드백 버튼을 누르면 추가적인 말풍선 내용을 확인할 수 있습니다.
완료 버튼 클릭 시 상황 학습 횟수가 +1 됩니다. 


## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
|    구현 내용   |   Mini   |   Pro   |
| :-------------: | :----------: | :----------: |
| <img src="https://github.com/user-attachments/assets/26d2ffcd-fbaa-4f35-991f-6242ecd2c365" width="250"> | <img src = "https://github.com/user-attachments/assets/8a10657c-6669-40df-b8be-558f4dc18a5c" width ="250"> | <img src = "https://github.com/user-attachments/assets/740577c7-f9fb-4dae-8f7c-5a78b7976d14" width ="250"> |


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
미니로 확인해보면 말풍선 안에서의 텍스트 레이아웃과 피드백 말풍선의 크기가 조금 이상합니다. 줄바꿈을 따로 제거하지 않은 상태에서 해결할 수 있는 방법을 찾아보려 했는데 그 부분이 잘 되지 않았던 것 같습니다. 좀 더 수정한 다음 추가 PR 올리겠습니다.

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
